### PR TITLE
printing stack trace of underlying thread error

### DIFF
--- a/src/main/java/fig/basic/Parallelizer.java
+++ b/src/main/java/fig/basic/Parallelizer.java
@@ -55,7 +55,10 @@ public class Parallelizer<T> {
     } catch(InterruptedException e) {
       throw Exceptions.bad("Interrupted");
     }
-    if(exception.value != null) throw new RuntimeException(exception.value);
+    if(exception.value != null) {
+      exception.value.printStackTrace();
+      throw new RuntimeException(exception.value);
+    }
   }
 
   // Test


### PR DESCRIPTION
I want to see where the exception was thrown in the underlying thread when the program terminates.
