### PR TITLE
quick fix

### DIFF
--- a/src/main/java/fig/basic/LogInfo.java
+++ b/src/main/java/fig/basic/LogInfo.java
@@ -352,7 +352,7 @@ class ThreadLogInfo {
     buf.delete(0, buf.length());
   }
 
-  private void rawPrint(Object o) {
+  private synchronized void rawPrint(Object o) {
     if (buffered) { buf.append(o); return; }
     flush();
     if (out != null) { out.print(o); out.flush(); }


### PR DESCRIPTION
We will look into the root cause later. Just finished 3 min of stress test, no problem yet.
According to this: http://docs.oracle.com/javase/tutorial/essential/concurrency/locksync.html
A thread can acquire a log it already owns, so nesting is probably fine.